### PR TITLE
Add a build option to be able to use the system libgit2 library + some compatibility changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,22 @@
 cmake_minimum_required(VERSION 3.0)
 
-set(BUILD_SHARED_LIBS ON)
-add_subdirectory(libgit2-0.19.0)
-include_directories(${CMAKE_SOURCE_DIR}/libgit2-0.19.0/include)
-project(kup)
-
 find_package(ECM REQUIRED NO_MODULE)
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
+
+project(kup)
+
+# Use this option if you want to use the system LibGit2 library.
+# This is not recommended unless you know what you are doing.
+option(USE_SYSTEM_LIBGIT2 "Don't set this option unless your are sure that your system version of LibGit2 library is fully compatible with Kup." OFF)
+if (USE_SYSTEM_LIBGIT2)
+  find_package(LibGit2 REQUIRED)
+  set(libgit_link_name git2)
+else (USE_SYSTEM_LIBGIT2)
+  set(BUILD_SHARED_LIBS ON)
+  add_subdirectory(libgit2-0.19.0)
+  include_directories(${CMAKE_SOURCE_DIR}/libgit2-0.19.0/include)
+  set(libgit_link_name git24kup)
+endif (USE_SYSTEM_LIBGIT2)
 
 if(${CMAKE_BUILD_TYPE} STREQUAL "Debug" OR ${CMAKE_BUILD_TYPE} STREQUAL "DebugFull")
   message(WARNING "enabling debug output!")

--- a/filedigger/CMakeLists.txt
+++ b/filedigger/CMakeLists.txt
@@ -29,7 +29,7 @@ KF5::KIOFileWidgets
 KF5::I18n
 KF5::IconThemes
 KF5::JobWidgets
-git24kup
+${libgit_link_name}
 )
 
 ########### install files ###############

--- a/filedigger/main.cpp
+++ b/filedigger/main.cpp
@@ -21,7 +21,11 @@
 #include "filedigger.h"
 #include "mergedvfs.h"
 
+#if LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 24
+#include <git2/global.h>
+#else
 #include <git2/threads.h>
+#endif
 
 #include <KAboutData>
 #include <KLocalizedString>
@@ -69,7 +73,11 @@ int main(int pArgCount, char **pArgArray) {
 	}
 
 	// This needs to be called first thing, before any other calls to libgit2.
+	#if LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 24
+	git_libgit2_init();
+	#else
 	git_threads_init();
+	#endif
 	MergedRepository *lRepository = new MergedRepository(NULL, lParser.positionalArguments().first(),
 	                                                     lParser.value("branch"));
 	if(!lRepository->open()) {
@@ -93,6 +101,10 @@ int main(int pArgCount, char **pArgArray) {
 	lFileDigger->show();
 	int lRetVal = lApp.exec();
 	delete lRepository;
+	#if LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 24
+	git_libgit2_shutdown();
+	#else
 	git_threads_shutdown();
+	#endif
 	return lRetVal;
 }

--- a/kioslave/CMakeLists.txt
+++ b/kioslave/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(kio_bup
 Qt5::Core
 KF5::KIOCore
 KF5::I18n
-git24kup
+${libgit_link_name}
 )
 
 install(TARGETS kio_bup DESTINATION ${PLUGIN_INSTALL_DIR})

--- a/kioslave/bupslave.cpp
+++ b/kioslave/bupslave.cpp
@@ -63,14 +63,22 @@ BupSlave::BupSlave(const QByteArray &pPoolSocket, const QByteArray &pAppSocket)
 {
 	mRepository = NULL;
 	mOpenFile = NULL;
+	#if LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 24
+	git_libgit2_init();
+	#else
 	git_threads_init();
+	#endif
 }
 
 BupSlave::~BupSlave() {
 	if(mRepository != NULL) {
 		delete mRepository;
 	}
+	#if LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR >= 24
+	git_libgit2_shutdown();
+	#else
 	git_threads_shutdown();
+	#endif
 }
 
 void BupSlave::close() {


### PR DESCRIPTION
Hi Simon,

I'm still working on packaging Kup for Debian and I manage to use the system libgit2 library with Kup and it seems promising. I test multiple backups and restorations using the system libgit2 0.24.5 available in Debian unstable.

This pull request includes changes that allow to use the system libgit2 even if this is officially not recommended for now. It also include some compatibility hacks for recent versions of libgit2.

Kind regards,
Thomas
