### PR TITLE
Fix build when CMAKE_BUILD_TYPE is not specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ else (USE_SYSTEM_LIBGIT2)
   set(libgit_link_name git24kup)
 endif (USE_SYSTEM_LIBGIT2)
 
-if(${CMAKE_BUILD_TYPE} STREQUAL "Debug" OR ${CMAKE_BUILD_TYPE} STREQUAL "DebugFull")
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug" OR "${CMAKE_BUILD_TYPE}" STREQUAL "DebugFull")
   message(WARNING "enabling debug output!")
   add_definitions(-DDEBUG)
 else()


### PR DESCRIPTION
If CMAKE_BUILD_TYPE is not specified, cmake aborts with

CMake Error at CMakeLists.txt:22 (if):
  if given arguments:

    "STREQUAL" "Debug" "OR" "STREQUAL" "DebugFull"

  Unknown arguments specified